### PR TITLE
Fix/internalize circular ref check

### DIFF
--- a/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectExtensions.cs
+++ b/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectExtensions.cs
@@ -10,17 +10,16 @@ namespace DebugUtils.Repr.Formatters.Fallback;
 internal static class HierarchicalObjectExtensions
 {
     public static JsonObject ToJsonObject(this object obj, ReprConfig config,
-        HashSet<int>? visited,
+        HashSet<int> visited,
         int depth)
     {
         var type = obj.GetType();
-        visited ??= new HashSet<int>();
         var objHash = RuntimeHelpers.GetHashCode(o: obj);
         var json = new JsonObject();
 
         json.Add(propertyName: "type", value: type.GetReprTypeName());
 
-        if (depth > 10)
+        if (depth > 5)
         {
             json.Add(propertyName: "value", value: "Truncated for brevity.");
             return json;

--- a/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectExtensions.cs
+++ b/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectExtensions.cs
@@ -38,7 +38,7 @@ internal static class HierarchicalObjectExtensions
                     break;
                 case Rune rune:
                     repr = rune.ToString();
-                    json.Add("Unicode Value", $"0x{rune.Value:X8}");
+                    json.Add(propertyName: "Unicode Value", value: $"0x{rune.Value:X8}");
                     break;
                 case char c:
                     repr = c switch
@@ -59,7 +59,7 @@ internal static class HierarchicalObjectExtensions
                         _ when Char.IsControl(c: c) => $"'\\u{(int)c:x4}'", // Control character
                         _ => $"'{c}'"
                     };
-                    json.Add("Unicode Value", $"0x{c:x4}");
+                    json.Add(propertyName: "Unicode Value", value: $"0x{c:x4}");
                     break;
                 default:
                     repr = obj.Repr(
@@ -79,8 +79,8 @@ internal static class HierarchicalObjectExtensions
                 var result = new JsonObject();
                 result.Add(propertyName: "type", value: type.GetReprTypeName());
                 result.Add(propertyName: "hashCode", value: $"0x{objHash:X8}");
-                json["type"] = "CircularReference";
-                json.Add("target", result);
+                json[propertyName: "type"] = "CircularReference";
+                json.Add(propertyName: "target", value: result);
                 return json;
             }
         }

--- a/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
+++ b/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
@@ -1,4 +1,5 @@
-﻿using DebugUtils.Repr.Interfaces;
+﻿using System.Text.Json;
+using DebugUtils.Repr.Interfaces;
 using DebugUtils.Repr.Records;
 
 namespace DebugUtils.Repr.Formatters.Fallback;
@@ -14,6 +15,6 @@ internal class HierarchicalObjectFormatter : IReprFormatter
         config = config.GetContainerConfig() with { TypeMode = TypeReprMode.AlwaysHide };
         visited ??= new HashSet<int>();
         return obj.ToJsonObject(config: config, visited: visited, depth: 0)
-                  .ToString();
+                  .ToJsonString(new JsonSerializerOptions { WriteIndented = false });
     }
 }

--- a/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
+++ b/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
@@ -15,6 +15,6 @@ internal class HierarchicalObjectFormatter : IReprFormatter
         config = config.GetContainerConfig() with { TypeMode = TypeReprMode.AlwaysHide };
         visited ??= new HashSet<int>();
         return obj.ToJsonObject(config: config, visited: visited, depth: 0)
-                  .ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+                  .ToJsonString(options: new JsonSerializerOptions { WriteIndented = false });
     }
 }

--- a/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
+++ b/DebugUtils/Repr/Formatters/Fallback/HierarchicalObjectFormatter.cs
@@ -12,8 +12,8 @@ internal class HierarchicalObjectFormatter : IReprFormatter
     public string ToRepr(object obj, ReprConfig config, HashSet<int>? visited)
     {
         config = config.GetContainerConfig() with { TypeMode = TypeReprMode.AlwaysHide };
-        var visited2 = new HashSet<int>();
-        return obj.ToJsonObject(config: config, visited: visited2, depth: 0)
+        visited ??= new HashSet<int>();
+        return obj.ToJsonObject(config: config, visited: visited, depth: 0)
                   .ToString();
     }
 }

--- a/DebugUtils/Repr/Formatters/Functions/MethodModifiers.cs
+++ b/DebugUtils/Repr/Formatters/Functions/MethodModifiers.cs
@@ -45,75 +45,27 @@ internal class MethodModifiers
     {
         var modifiers = new List<string>();
 
-        // 1. Add Access Modifier
-        if (IsPublic)
+        foreach (var (condition, name) in new[]
+                 {
+                     (IsPublic, "public"),
+                     (IsPrivate, "private"),
+                     (IsProtected, "protected"),
+                     (IsInternal, "internal"),
+                     (IsStatic, "static"),
+                     (IsAbstract, "abstract"),
+                     (IsVirtual, "virtual"),
+                     (IsOverride, "override"),
+                     (IsSealed, "sealed"),
+                     (IsAsync, "async"),
+                     (IsExtern, "extern"),
+                     (IsUnsafe, "unsafe"),
+                     (IsGeneric, "generic")
+                 })
         {
-            modifiers.Add(item: "public");
-        }
-
-        if (IsPrivate)
-        {
-            modifiers.Add(item: "private");
-        }
-
-        if (IsProtected)
-        {
-            modifiers.Add(item: "protected");
-        }
-
-        if (IsInternal)
-        {
-            modifiers.Add(item: "internal");
-        }
-
-        // 2. Add Scope/Inheritance Modifiers
-        // Note: C# syntax doesn't allow 'virtual' and 'abstract' with 'sealed'
-        // so the order here handles the common combinations correctly.
-
-        if (IsStatic)
-        {
-            modifiers.Add(item: "static");
-        }
-
-        if (IsAbstract)
-        {
-            modifiers.Add(item: "abstract");
-        }
-
-        if (IsVirtual)
-        {
-            modifiers.Add(item: "virtual");
-        }
-
-        if (IsOverride)
-        {
-            modifiers.Add(item: "override");
-        }
-
-        if (IsSealed)
-        {
-            modifiers.Add(item: "sealed");
-        }
-
-        // 3. Add Other Modifiers
-        if (IsAsync)
-        {
-            modifiers.Add(item: "async");
-        }
-
-        if (IsExtern)
-        {
-            modifiers.Add(item: "extern");
-        }
-
-        if (IsUnsafe)
-        {
-            modifiers.Add(item: "unsafe");
-        }
-
-        if (IsGeneric)
-        {
-            modifiers.Add(item: "generic");
+            if (condition)
+            {
+                modifiers.Add(item: name);
+            }
         }
 
         // Join the list into a single string
@@ -130,47 +82,32 @@ internal static class MethodModifiersExtensions
     public static JsonObject ToJsonObject(this MethodModifiers methodModifiers, ReprConfig config,
         HashSet<int> visited, int depth)
     {
-        var result = new JsonObject();
-        result.Add(propertyName: "isPublic",
-            value: methodModifiers.IsPublic.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isPrivate",
-            value: methodModifiers.IsPrivate.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isProtected",
-            value: methodModifiers.IsProtected.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isInternal",
-            value: methodModifiers.IsInternal.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isStatic",
-            value: methodModifiers.IsStatic.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isVirtual",
-            value: methodModifiers.IsVirtual.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isOverride",
-            value: methodModifiers.IsOverride.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isAbstract",
-            value: methodModifiers.IsAbstract.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isSealed",
-            value: methodModifiers.IsSealed.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isAsync",
-            value: methodModifiers.IsAsync.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isGeneric",
-            value: methodModifiers.IsGeneric.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isExtern",
-            value: methodModifiers.IsExtern.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        result.Add(propertyName: "isUnsafe",
-            value: methodModifiers.IsUnsafe.ToJsonObject(config: config, visited: visited,
-                depth: depth + 1));
-        return result;
+        var modifiers = new JsonArray();
+
+        foreach (var (condition, name) in new[]
+                 {
+                     (methodModifiers.IsPublic, "public"),
+                     (methodModifiers.IsPrivate, "private"),
+                     (methodModifiers.IsProtected, "protected"),
+                     (methodModifiers.IsInternal, "internal"),
+                     (methodModifiers.IsStatic, "static"),
+                     (methodModifiers.IsAbstract, "abstract"),
+                     (methodModifiers.IsVirtual, "virtual"),
+                     (methodModifiers.IsOverride, "override"),
+                     (methodModifiers.IsSealed, "sealed"),
+                     (methodModifiers.IsAsync, "async"),
+                     (methodModifiers.IsExtern, "extern"),
+                     (methodModifiers.IsUnsafe, "unsafe"),
+                     (methodModifiers.IsGeneric, "generic")
+                 })
+        {
+            if (condition)
+            {
+                modifiers.Add(value: name);
+            }
+        }
+
+        return new JsonObject { [propertyName: "modifiers"] = modifiers };
     }
 
     public static bool IsOverrideMethod(this MethodInfo method)

--- a/DebugUtils/Repr/Formatters/Standard/TextFormatters.cs
+++ b/DebugUtils/Repr/Formatters/Standard/TextFormatters.cs
@@ -32,29 +32,24 @@ internal class CharFormatter : IReprFormatter
     public string ToRepr(object obj, ReprConfig config, HashSet<int>? visited)
     {
         var value = (char)obj;
-        switch (value)
+        return value switch
         {
-            case '\'': return "'''"; // Single quote
-            case '\"': return "'\"'"; // Double quote
-            case '\\': return @"'\\'"; // Backslash
-            case '\0': return @"'\0'"; // Null
-            case '\a': return @"'\a'"; // Alert
-            case '\b': return @"'\b'"; // Backspace
-            case '\f': return @"'\f'"; // Form feed
-            case '\n': return @"'\n'"; // Newline
-            case '\r': return @"'\r'"; // Carriage return
-            case '\t': return @"'\t'"; // Tab
-            case '\v': return @"'\v'"; // Vertical tab
-            case '\u00a0': return "'nbsp'"; // Non-breaking space
-            case '\u00ad': return "'shy'"; // Soft Hyphen
-        }
-
-        if (Char.IsControl(c: value))
-        {
-            return $"'\\u{(int)value:X4}'";
-        }
-
-        return $"'{value}'";
+            '\'' => "'''", // Single quote
+            '\"' => "'\"'", // Double quote
+            '\\' => @"'\\'", // Backslash
+            '\0' => @"'\0'", // Null
+            '\a' => @"'\a'", // Alert
+            '\b' => @"'\b'", // Backspace
+            '\f' => @"'\f'", // Form feed
+            '\n' => @"'\n'", // Newline
+            '\r' => @"'\r'", // Carriage return
+            '\t' => @"'\t'", // Tab
+            '\v' => @"'\v'", // Vertical tab
+            '\u00a0' => "'nbsp'", // Non-breaking space
+            '\u00ad' => "'shy'", // Soft Hyphen
+            _ when Char.IsControl(c: value) => $"'\\u{(int)value:X4}'", // Control character
+            _ => $"'{value}'"
+        };
     }
 }
 

--- a/DebugUtils/Repr/Records/ReprConfig.cs
+++ b/DebugUtils/Repr/Records/ReprConfig.cs
@@ -498,16 +498,17 @@ public record ReprConfig(
         ContainerReprMode: ContainerReprMode.UseDefaultConfig,
         IntMode: IntReprMode.Decimal,
         TypeMode: TypeReprMode.HideObvious);
+
     /// <summary>
     /// Default configuration for hierarchical JSON-style output.
     /// Optimized for structured readability and JSON compatibility.
     /// </summary>
     public static ReprConfig HierarchicalDefaults => new(
-        FloatMode: FloatReprMode.Exact,      // ✅ JSON-friendly float formatting
-        FloatPrecision: -1,                     // ✅ Reasonable precision for JSON
-        IntMode: IntReprMode.Decimal,          // ✅ JSON standard - no hex
+        FloatMode: FloatReprMode.Exact, // ✅ JSON-friendly float formatting
+        FloatPrecision: -1, // ✅ Reasonable precision for JSON
+        IntMode: IntReprMode.Decimal, // ✅ JSON standard - no hex
         ContainerReprMode: ContainerReprMode.UseParentConfig,
-        TypeMode: TypeReprMode.AlwaysHide,     // ✅ JSON has type info in structure
+        TypeMode: TypeReprMode.AlwaysHide, // ✅ JSON has type info in structure
         FormattingMode: FormattingMode.Hierarchical
     );
 }

--- a/DebugUtils/Repr/Records/ReprConfig.cs
+++ b/DebugUtils/Repr/Records/ReprConfig.cs
@@ -330,24 +330,30 @@ public enum FormattingMode
     Reflection,
 
     /// <summary>
-    /// <para><strong>⚠️ EXPERIMENTAL:</strong> This feature is experimental and may change in future versions.</para> 
-    /// Always uses reflection-based formatting with hierarchical JSON-like output.
-    /// Produces structured data suitable for analysis, tooling, and machine processing.
+    /// Produces structured, JSON-like output optimized for debugging and analysis.
+    /// Shows object hierarchy, type information, and handles circular references.
+    /// <para><strong>Why Use This:</strong> Unlike standard JSON serializers, hierarchical mode 
+    /// preserves debugging information like exact numeric representations, handles circular 
+    /// references gracefully, and provides type metadata for every value.</para>
     /// </summary>
     /// <remarks>
-    /// <para>Generates JSON-compatible output with type and value information:</para>
+    /// <para>Output uses JSON-style syntax but includes debugging extensions that may not be valid JSON:</para>
     /// <list type="bullet">
-    /// <item><description>Each object includes type metadata</description></item>
-    /// <item><description>Values are structured for easy parsing</description></item>
-    /// <item><description>Maintains object hierarchy and relationships</description></item>
-    /// <item><description>Suitable for integration with analysis tools</description></item>
+    /// <item><description>Type metadata for all values</description></item>
+    /// <item><description>Special numeric formats (hex, binary, exact floats)</description></item>
+    /// <item><description>Error information for problematic properties</description></item>
+    /// <item><description>Circular reference detection and markers</description></item>
     /// </list>
-    /// <para>Ideal for automated processing, data export, and structured debugging scenarios.</para>
+    /// 
+    /// <para><strong>Ideal for:</strong> IDE integration, automated analysis, complex debugging scenarios.</para>
+    /// <para><strong>Not for:</strong> Data interchange, API responses, or storage. Use dedicated JSON serializers for those cases.</para>
     /// </remarks>
     /// <example>
-    /// Standard mode: Person(Name: "John", Age: 30)
-    /// Hierarchical mode: {"type":"Person","value":{"Name":"John","Age":30}}
+    /// Standard mode: Person(Name: "John", Age: int(30))
+    /// Hierarchical mode: {"type":"Person","Name":{"type":"string","value":"John"},"Age":{"type":"int","value":"30"}}
     /// </example>
+    /// <seealso cref="System.Text.Json.JsonSerializer"/>
+    /// <seealso cref="ReprConfig.HierarchicalDefaults"/>
     Hierarchical
 }
 
@@ -492,4 +498,16 @@ public record ReprConfig(
         ContainerReprMode: ContainerReprMode.UseDefaultConfig,
         IntMode: IntReprMode.Decimal,
         TypeMode: TypeReprMode.HideObvious);
+    /// <summary>
+    /// Default configuration for hierarchical JSON-style output.
+    /// Optimized for structured readability and JSON compatibility.
+    /// </summary>
+    public static ReprConfig HierarchicalDefaults => new(
+        FloatMode: FloatReprMode.Exact,      // ✅ JSON-friendly float formatting
+        FloatPrecision: -1,                     // ✅ Reasonable precision for JSON
+        IntMode: IntReprMode.Decimal,          // ✅ JSON standard - no hex
+        ContainerReprMode: ContainerReprMode.UseParentConfig,
+        TypeMode: TypeReprMode.AlwaysHide,     // ✅ JSON has type info in structure
+        FormattingMode: FormattingMode.Hierarchical
+    );
 }

--- a/DebugUtils/Repr/ReprExtensions.cs
+++ b/DebugUtils/Repr/ReprExtensions.cs
@@ -263,8 +263,8 @@ public static partial class ReprExtensions
         var type = typeof(T);
         var value = type.GetProperty(name: "Value")!.GetValue(obj: nullable)!;
         var valueRepr = value.ToJsonObject(config: config, visited: visited, depth: 0);
-        valueRepr["type"] = $"{reprName}";
-        
+        valueRepr[propertyName: "type"] = $"{reprName}";
+
         return valueRepr.ToString();
     }
 }

--- a/DebugUtils/Repr/ReprExtensions.cs
+++ b/DebugUtils/Repr/ReprExtensions.cs
@@ -136,10 +136,9 @@ public static partial class ReprExtensions
         config ??= ReprConfig.GlobalDefaults;
         visited ??= new HashSet<int>();
         var id = RuntimeHelpers.GetHashCode(o: obj);
-
         if (config.FormattingMode == FormattingMode.Hierarchical)
         {
-            config = ReprConfig.HierarchicalDefaults;
+            config = config with { TypeMode = TypeReprMode.AlwaysHide };
         }
 
         if (obj.IsNullableStruct())

--- a/DebugUtils/Repr/TypeLibraries/TypeInspector.cs
+++ b/DebugUtils/Repr/TypeLibraries/TypeInspector.cs
@@ -17,7 +17,7 @@ internal static class TypeInspector
                || type == typeof(short)
                || type == typeof(int)
                || type == typeof(long)
-               #if NET7_0_OR_GREATER
+            #if NET7_0_OR_GREATER
                || type == typeof(Int128)
             #endif
             ;
@@ -29,7 +29,7 @@ internal static class TypeInspector
                || type == typeof(ushort)
                || type == typeof(uint)
                || type == typeof(ulong)
-               #if NET7_0_OR_GREATER
+            #if NET7_0_OR_GREATER
                || type == typeof(Int128)
             #endif
             ;

--- a/README.md
+++ b/README.md
@@ -228,6 +228,25 @@ var showTypes = new ReprConfig(TypeMode: TypeReprMode.AlwaysShow);
 new[] {1, 2, 3}.Repr(showTypes);  // 1DArray([int(1), int(2), int(3)])
 ```
 
+### Hierarchical Display
+
+```csharp
+public class Person
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+
+    public Person(string name, int age)
+    {
+        Name = name;
+        Age = age;
+    }
+}
+var a = new Person(name: "Lumi", age: 28);
+var config = new ReprConfig(FormattingMode: FormattingMode.Hierarchical);
+a.Repr(config: config); //{"type":"Person","Name":{"type":"string","value":"Lumi"},"Age":{"type":"int","value":"28"}}
+```
+
 ## Real-World Use Cases
 
 ### Competitive Programming


### PR DESCRIPTION
changes made
1. fixed hierarchical mode
  1. changed function modifiers representation method
  2. fixed circular referencing issue
  3. fixed double circular reference checking issue
  4. prevented string, char, rune to call another repr call and have its own hierarchical expression
  5. changed to not include indents and line feeds